### PR TITLE
feat: add public leaderboard command with wealth brackets

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -131,9 +131,21 @@ class MafiaWarBot {
     }
 
     try {
-      // Defer reply immediately for commands that might take time (except ping)
+      // Defer reply immediately for commands that might take time (except ping and casino gambling)
       if (interaction.commandName !== "ping") {
-        await interaction.deferReply({ flags: 64 }); // 64 = ephemeral flag
+        // Casino gambling results should be public, so defer without ephemeral flag
+        if (interaction.commandName === "casino") {
+          const subcommand = interaction.options.getSubcommand();
+          if (subcommand === "slots" || subcommand === "roulette") {
+            await interaction.deferReply(); // Public reply for gambling results
+          } else {
+            await interaction.deferReply({ flags: 64 }); // Ephemeral for info/errors
+          }
+        } else if (interaction.commandName === "leaderboard") {
+          await interaction.deferReply(); // Public reply for leaderboard
+        } else {
+          await interaction.deferReply({ flags: 64 }); // 64 = ephemeral flag
+        }
       }
 
       // Create command context

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -41,7 +41,9 @@ const helpCommand: Command = {
           { name: "Economy & Money", value: "economy" },
           { name: "Crime & Activities", value: "crime" },
           { name: "Business & Assets", value: "business" },
+          { name: "Casino & Gambling", value: "casino" },
           { name: "Available Crimes", value: "crimes" },
+          { name: "Leaderboard", value: "leaderboard" },
           { name: "System & Info", value: "system" }
         )
     ),
@@ -103,9 +105,19 @@ const helpCommand: Command = {
             value: "business",
           },
           {
+            label: "🎰 Casino & Gambling",
+            description: "Slots, roulette, betting games",
+            value: "casino",
+          },
+          {
             label: "📋 Available Crimes",
             description: "View all crimes & requirements",
             value: "crimes",
+          },
+          {
+            label: "🏆 Leaderboard",
+            description: "View top players by level & wealth",
+            value: "leaderboard",
           },
           {
             label: "⚙️ System & Info",
@@ -134,7 +146,12 @@ const helpCommand: Command = {
 
       // Alternative collector for when channel is not available (ephemeral interactions)
       let altCollector = null;
-      if (!collector && reply && typeof reply === 'object' && 'createMessageComponentCollector' in reply) {
+      if (
+        !collector &&
+        reply &&
+        typeof reply === "object" &&
+        "createMessageComponentCollector" in reply
+      ) {
         altCollector = (reply as any).createMessageComponentCollector({
           filter: (i: any) => i.user.id === interaction.user.id,
           componentType: ComponentType.StringSelect,
@@ -340,6 +357,62 @@ function createHelpEmbed(category: string, character: any): EmbedBuilder {
         );
       break;
 
+    case "casino":
+      embed
+        .setTitle("🎰 Casino & Gambling")
+        .setDescription("Risk it all at the underground casino")
+        .addFields(
+          {
+            name: "`/casino info`",
+            value: "ℹ️ View casino rules, game mechanics, and betting limits",
+            inline: false,
+          },
+          {
+            name: "`/casino slots <bet>`",
+            value:
+              "🎰 Play the slot machine\n💡 Three matching symbols in middle row wins!\n🎯 Bet: $10 - $10,000",
+            inline: false,
+          },
+          {
+            name: "`/casino roulette <bet_type> <amount>`",
+            value:
+              "🎡 Play roulette with various betting options\n🔴 Even money: Red, Black, Even, Odd, 1-18, 19-36\n💰 Dozens: 1st/2nd/3rd dozen (2:1)\n🎯 Straight: Single number (35:1)\n💵 Bet: $5 - $50,000",
+            inline: false,
+          },
+          {
+            name: "⚠️ Gambling Tips",
+            value:
+              "• House always has an edge (~5%)\n• Set a budget and stick to it\n• Use `/wallet` to check balance\n• Gamble responsibly",
+            inline: false,
+          }
+        );
+      break;
+
+    case "leaderboard":
+      embed
+        .setTitle("🏆 Leaderboard")
+        .setDescription("See how you rank against other players")
+        .addFields(
+          {
+            name: "`/leaderboard`",
+            value: "🏆 View top 25 players ranked by level and wealth brackets\nShows player names, levels, and wealth tiers (not exact amounts)",
+            inline: false,
+          },
+          {
+            name: "💡 Wealth Brackets",
+            value:
+              "💸 <$10K\n💵 $10K-$50K\n💴 $50K-$100K\n💶 $100K-$250K\n💷 $250K-$500K\n💰 $500K-$1M\n🏦 $1M-$5M\n🏛️ $5M-$10M\n👑 $10M+",
+            inline: true,
+          },
+          {
+            name: "🎯 Tips",
+            value:
+              "• Level up by committing crimes\n• Earn money through crimes and businesses\n• Bank your money to increase wealth safely\n• Buy businesses for passive income",
+            inline: true,
+          }
+        );
+      break;
+
     case "system":
       embed
         .setTitle("⚙️ System & Information")
@@ -374,7 +447,7 @@ function createHelpEmbed(category: string, character: any): EmbedBuilder {
           {
             name: "📋 Quick Reference",
             value:
-              "**Essential Commands:**\n`/user-create` - Create character\n`/profile` - View stats\n`/crime <type>` - Commit crimes\n`/wallet` - Check money\n`/assets` - Browse businesses",
+              "**Essential Commands:**\n`/user-create` - Create character\n`/profile` - View stats\n`/crime <type>` - Commit crimes\n`/wallet` - Check money\n`/assets` - Browse businesses\n`/leaderboard` - View rankings",
             inline: true,
           },
           {

--- a/src/commands/leaderboard.ts
+++ b/src/commands/leaderboard.ts
@@ -1,0 +1,121 @@
+import { EmbedBuilder, SlashCommandBuilder } from "discord.js";
+import { BotBranding } from "../config/bot";
+import { Command, CommandContext, CommandResult } from "../types/command";
+import DatabaseManager from "../utils/DatabaseManager";
+import { ResponseUtil, logger } from "../utils/ResponseUtil";
+
+const leaderboardCommand: Command = {
+  data: new SlashCommandBuilder()
+    .setName("leaderboard")
+    .setDescription("View the top players ranked by level and wealth"),
+
+  async execute(context: CommandContext): Promise<CommandResult> {
+    const { interaction } = context;
+
+    try {
+      // Get all characters with user data, ordered by level (descending), then by total wealth
+      const characters = await DatabaseManager.getClient().character.findMany({
+        include: {
+          user: true,
+        },
+        orderBy: [
+          { level: "desc" },
+          { bankBalance: "desc" },
+          { cashOnHand: "desc" },
+        ],
+        take: 25, // Show top 25 players
+      });
+
+      if (characters.length === 0) {
+        const noPlayersEmbed = ResponseUtil.error(
+          "No Players Found",
+          "There are no registered players in the game yet."
+        );
+        await ResponseUtil.smartReply(interaction, {
+          embeds: [noPlayersEmbed],
+          ephemeral: false, // Make it public
+        });
+        return { success: true };
+      }
+
+      // Create leaderboard embed
+      const leaderboardEmbed = new EmbedBuilder()
+        .setTitle("🏆 Mafia Leaderboard")
+        .setDescription("Top criminals ranked by level and wealth")
+        .setColor(BotBranding.getThemeColor())
+        .setTimestamp();
+
+      // Function to get wealth bracket
+      const getWealthBracket = (totalWealth: number): string => {
+        if (totalWealth < 10000) return "💸 <$10K";
+        if (totalWealth < 50000) return "💵 $10K-$50K";
+        if (totalWealth < 100000) return "💴 $50K-$100K";
+        if (totalWealth < 250000) return "💶 $100K-$250K";
+        if (totalWealth < 500000) return "💷 $250K-$500K";
+        if (totalWealth < 1000000) return "💰 $500K-$1M";
+        if (totalWealth < 5000000) return "🏦 $1M-$5M";
+        if (totalWealth < 10000000) return "🏛️ $5M-$10M";
+        return "👑 $10M+";
+      };
+
+      // Add leaderboard entries
+      let leaderboardText = "";
+      characters.forEach((character, index) => {
+        const rank = index + 1;
+        const totalWealth = character.cashOnHand + character.bankBalance;
+
+        // Get wealth bracket instead of exact amount
+        const wealthBracket = getWealthBracket(totalWealth);
+
+        // Add rank emoji for top 3
+        let rankEmoji = "";
+        if (rank === 1) rankEmoji = "🥇";
+        else if (rank === 2) rankEmoji = "🥈";
+        else if (rank === 3) rankEmoji = "🥉";
+        else rankEmoji = `${rank}.`;
+
+        leaderboardText += `${rankEmoji} **${character.name}** (Level ${character.level})\n${wealthBracket}\n\n`;
+      });
+
+      leaderboardEmbed.addFields({
+        name: "Rankings",
+        value: leaderboardText || "No data available",
+        inline: false,
+      });
+
+      // Add footer with additional info
+      leaderboardEmbed.setFooter({
+        text: `${BotBranding.getName()} • Showing top ${
+          characters.length
+        } players`,
+      });
+
+      await ResponseUtil.smartReply(interaction, {
+        embeds: [leaderboardEmbed],
+        ephemeral: false, // Make it public so everyone can see
+      });
+
+      logger.info(`Leaderboard command executed successfully`);
+      return { success: true };
+    } catch (error) {
+      logger.error("Error in leaderboard command:", error);
+
+      const errorEmbed = ResponseUtil.error(
+        "Leaderboard Error",
+        "An error occurred while fetching the leaderboard. Please try again later."
+      );
+
+      await ResponseUtil.smartReply(interaction, {
+        embeds: [errorEmbed],
+        ephemeral: true,
+      });
+
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
+  },
+};
+
+export default leaderboardCommand;


### PR DESCRIPTION
- Add /leaderboard command showing top 25 players ranked by level and wealth
- Display wealth in privacy-friendly brackets instead of exact amounts
- Public visibility so all users can see rankings in channel
- Wealth tiers from <$10K to $10M+ with themed emojis
- Medal emojis for top 3 positions (🥇🥈🥉)
- Updated bot.ts to make leaderboard replies public instead of ephemeral
- Added leaderboard section to help command with bracket explanations