### PR TITLE
feat: standardize currency formatting with BotBranding.formatCurrency()

### DIFF
--- a/scripts/testing/assetValidation.ts
+++ b/scripts/testing/assetValidation.ts
@@ -6,9 +6,10 @@
  */
 
 import { PrismaClient } from "@prisma/client";
-import { assetTemplates } from "../src/data/assets";
-import { AssetService } from "../src/services/AssetService";
-import { logger } from "../src/utils/ResponseUtil";
+import { BotBranding } from "../../src/config/bot";
+import { assetTemplates } from "../../src/data/assets";
+import { AssetService } from "../../src/services/AssetService";
+import { logger } from "../../src/utils/ResponseUtil";
 
 const prisma = new PrismaClient();
 
@@ -139,7 +140,7 @@ async function main() {
       logger.info(
         `  Lv.${level}: ${
           asset.name
-        } - $${price.toLocaleString()} (${paybackHours}h payback)`
+        } - ${BotBranding.formatCurrency(price)} (${paybackHours}h payback)`
       );
     });
 

--- a/src/commands/casino.ts
+++ b/src/commands/casino.ts
@@ -1,4 +1,5 @@
 import { SlashCommandBuilder } from "discord.js";
+import { BotBranding } from "../config/bot";
 import CasinoService from "../services/CasinoService";
 import JailService from "../services/JailService";
 import { Command, CommandContext, CommandResult } from "../types/command";
@@ -135,11 +136,23 @@ const casinoCommand: Command = {
           );
 
           if (!transaction.success) {
-            const errorEmbed = ResponseUtil.error(
-              "🎰 Slots Error",
-              transaction.message
-            );
-            await interaction.editReply({ embeds: [errorEmbed] });
+            // Check if this is an insufficient funds error - make it private
+            if (transaction.error === "Insufficient funds") {
+              const errorEmbed = ResponseUtil.error(
+                "🎰 Insufficient Funds",
+                transaction.message
+              );
+              // Delete the original deferred message and send ephemeral followup
+              await interaction.deleteReply();
+              await interaction.followUp({ embeds: [errorEmbed], ephemeral: true });
+            } else {
+              // Other errors can be public
+              const errorEmbed = ResponseUtil.error(
+                "🎰 Slots Error",
+                transaction.message
+              );
+              await interaction.editReply({ embeds: [errorEmbed] });
+            }
             return { success: false, error: transaction.error };
           }
 
@@ -150,8 +163,8 @@ const casinoCommand: Command = {
           return {
             success: true,
             message: result.isWin
-              ? `Won $${result.payout.toLocaleString()}!`
-              : `Lost $${result.betAmount.toLocaleString()}`,
+              ? `Won ${BotBranding.formatCurrency(result.payout)}!`
+              : `Lost ${BotBranding.formatCurrency(result.betAmount)}`,
           };
         }
 
@@ -210,11 +223,23 @@ const casinoCommand: Command = {
           );
 
           if (!transaction.success) {
-            const errorEmbed = ResponseUtil.error(
-              "🎡 Roulette Error",
-              transaction.message
-            );
-            await interaction.editReply({ embeds: [errorEmbed] });
+            // Check if this is an insufficient funds error - make it private
+            if (transaction.error === "Insufficient funds") {
+              const errorEmbed = ResponseUtil.error(
+                "🎡 Insufficient Funds",
+                transaction.message
+              );
+              // Delete the original deferred message and send ephemeral followup
+              await interaction.deleteReply();
+              await interaction.followUp({ embeds: [errorEmbed], ephemeral: true });
+            } else {
+              // Other errors can be public
+              const errorEmbed = ResponseUtil.error(
+                "🎡 Roulette Error",
+                transaction.message
+              );
+              await interaction.editReply({ embeds: [errorEmbed] });
+            }
             return { success: false, error: transaction.error };
           }
 
@@ -228,8 +253,8 @@ const casinoCommand: Command = {
           return {
             success: true,
             message: result.isWin
-              ? `Won $${result.payout.toLocaleString()}!`
-              : `Lost $${result.betAmount.toLocaleString()}`,
+              ? `Won ${BotBranding.formatCurrency(result.payout)}!`
+              : `Lost ${BotBranding.formatCurrency(result.betAmount)}`,
           };
         }
 

--- a/src/commands/crypto.ts
+++ b/src/commands/crypto.ts
@@ -437,28 +437,28 @@ async function handleBuy(context: CommandContext): Promise<CommandResult> {
     embed.addFields(
       {
         name: "💰 Transaction Details",
-        value: `**Spent:** $${cashAmount.toLocaleString()}\n**Fee:** $${fee.toLocaleString()} (3%)\n**Net Amount:** $${netAmount.toLocaleString()}`,
+        value: `**Spent:** ${BotBranding.formatCurrency(cashAmount)}\n**Fee:** ${BotBranding.formatCurrency(fee)} (3%)\n**Net Amount:** ${BotBranding.formatCurrency(netAmount)}`,
         inline: true,
       },
       {
         name: `₿ ${coin.symbol} Acquired`,
         value: `**Amount:** ${result.data?.coinAmount?.toFixed(6)} ${
           coin.symbol
-        }\n**Price:** $${currentPrice.toFixed(2)} per ${
+        }\n**Price:** ${BotBranding.formatCurrency(parseFloat(currentPrice.toFixed(2)))} per ${
           coin.symbol
-        }\n**Value:** $${netAmount.toLocaleString()}`,
+        }\n**Value:** ${BotBranding.formatCurrency(netAmount)}`,
         inline: true,
       },
       {
         name: "💵 Updated Balance",
-        value: `**Cash:** $${
+        value: `**Cash:** ${
           paymentMethod === "cash"
-            ? result.data?.fromBalance.toLocaleString()
-            : balances.cashOnHand.toLocaleString()
-        }\n**Bank:** $${
+            ? BotBranding.formatCurrency(result.data?.fromBalance || 0)
+            : BotBranding.formatCurrency(balances.cashOnHand)
+        }\n**Bank:** ${
           paymentMethod === "bank"
-            ? result.data?.fromBalance.toLocaleString()
-            : balances.bankBalance.toLocaleString()
+            ? BotBranding.formatCurrency(result.data?.fromBalance || 0)
+            : BotBranding.formatCurrency(balances.bankBalance)
         }`,
         inline: false,
       }
@@ -572,11 +572,9 @@ async function handleSell(context: CommandContext): Promise<CommandResult> {
         name: "💡 Sell Maximum Instead?",
         value: `**Your Holdings:** ${maxCoinAmount.toFixed(6)} ${
           coin.symbol
-        }\n**Current Price:** $${maxPrice.toFixed(
-          2
-        )}\n**Gross Value:** $${Math.floor(
+        }\n**Current Price:** ${BotBranding.formatCurrency(parseFloat(maxPrice.toFixed(2)))}\n**Gross Value:** ${BotBranding.formatCurrency(Math.floor(
           maxGrossAmount
-        ).toLocaleString()}\n**Fee (4%):** $${maxFee.toLocaleString()}\n**You'd Receive:** $${maxNetCash.toLocaleString()}`,
+        ))}\n**Fee (4%):** ${BotBranding.formatCurrency(maxFee)}\n**You'd Receive:** ${BotBranding.formatCurrency(maxNetCash)}`,
         inline: false,
       });
 
@@ -644,25 +642,25 @@ async function handleSell(context: CommandContext): Promise<CommandResult> {
               name: `₿ ${coin.symbol} Sold`,
               value: `**Amount:** ${maxCoinAmount.toFixed(6)} ${
                 coin.symbol
-              }\n**Price:** $${maxPrice.toFixed(2)} per ${
+              }\n**Price:** ${BotBranding.formatCurrency(parseFloat(maxPrice.toFixed(2)))} per ${
                 coin.symbol
-              }\n**Gross Value:** $${Math.floor(
+              }\n**Gross Value:** ${BotBranding.formatCurrency(Math.floor(
                 maxGrossAmount
-              ).toLocaleString()}`,
+              ))}`,
               inline: true,
             },
             {
               name: "💰 Cash Received",
-              value: `**Gross Amount:** $${Math.floor(
+              value: `**Gross Amount:** ${BotBranding.formatCurrency(Math.floor(
                 maxGrossAmount
-              ).toLocaleString()}\n**Fee:** $${maxFee.toLocaleString()} (4%)\n**Net Cash:** $${maxNetCash.toLocaleString()}`,
+              ))}\n**Fee:** ${BotBranding.formatCurrency(maxFee)} (4%)\n**Net Cash:** ${BotBranding.formatCurrency(maxNetCash)}`,
               inline: true,
             },
             {
               name: "💵 Updated Balance",
-              value: `**Cash:** $${maxResult.data?.toBalance.toLocaleString()}\n**${
+              value: `**Cash:** ${BotBranding.formatCurrency(maxResult.data?.toBalance || 0)}\n**${
                 coin.symbol
-              } Remaining:** 0.000000\n**Total Worth:** $${maxResult.data?.toBalance.toLocaleString()}`,
+              } Remaining:** 0.000000\n**Total Worth:** ${BotBranding.formatCurrency(maxResult.data?.toBalance || 0)}`,
               inline: false,
             }
           );
@@ -751,25 +749,25 @@ async function handleSell(context: CommandContext): Promise<CommandResult> {
         name: `₿ ${coin.symbol} Sold`,
         value: `**Amount:** ${coinAmount.toFixed(6)} ${
           coin.symbol
-        }\n**Price:** $${currentPrice.toFixed(2)} per ${
+        }\n**Price:** ${BotBranding.formatCurrency(parseFloat(currentPrice.toFixed(2)))} per ${
           coin.symbol
-        }\n**Gross Value:** $${Math.floor(grossAmount).toLocaleString()}`,
+        }\n**Gross Value:** ${BotBranding.formatCurrency(Math.floor(grossAmount))}`,
         inline: true,
       },
       {
         name: "💰 Cash Received",
-        value: `**Gross Amount:** $${Math.floor(
+        value: `**Gross Amount:** ${BotBranding.formatCurrency(Math.floor(
           grossAmount
-        ).toLocaleString()}\n**Fee:** $${fee.toLocaleString()} (4%)\n**Net Cash:** $${netCash.toLocaleString()}`,
+        ))}\n**Fee:** ${BotBranding.formatCurrency(fee)} (4%)\n**Net Cash:** ${BotBranding.formatCurrency(netCash)}`,
         inline: true,
       },
       {
         name: "💵 Updated Balance",
-        value: `**Cash:** $${result.data?.toBalance.toLocaleString()}\n**${
+        value: `**Cash:** ${BotBranding.formatCurrency(result.data?.toBalance || 0)}\n**${
           coin.symbol
         } Remaining:** ${(currentHolding - coinAmount).toFixed(
           6
-        )}\n**Total Worth:** $${result.data?.toBalance.toLocaleString()}`,
+        )}\n**Total Worth:** ${BotBranding.formatCurrency(result.data?.toBalance || 0)}`,
         inline: false,
       }
     );

--- a/src/data/casino.ts
+++ b/src/data/casino.ts
@@ -274,7 +274,7 @@ export const casinoConfig: CasinoConfig = {
   },
   roulette: {
     minBet: 5,
-    maxBet: 50000,
+    maxBet: 5000000000,
     houseEdge: 0.0526, // 5.26% house edge (American roulette with 0 and 00)
   },
 };

--- a/src/services/AssetService.ts
+++ b/src/services/AssetService.ts
@@ -191,11 +191,11 @@ export class AssetService {
 
     if (availableFunds < totalCost) {
       missing.push(
-        `$${totalCost.toLocaleString()} total (have $${availableFunds.toLocaleString()})`
+        `${BotBranding.formatCurrency(totalCost)} total (have ${BotBranding.formatCurrency(availableFunds)})`
       );
       return {
         canPurchase: false,
-        reason: `Insufficient funds - need $${totalCost.toLocaleString()}, have $${availableFunds.toLocaleString()}`,
+        reason: `Insufficient funds - need ${BotBranding.formatCurrency(totalCost)}, have ${BotBranding.formatCurrency(availableFunds)}`,
         requirements: missing,
       };
     }
@@ -268,7 +268,7 @@ export class AssetService {
             case "cash":
               if (currentUser.character.cashOnHand < totalCost) {
                 throw new Error(
-                  `Insufficient cash - need $${totalCost.toLocaleString()}, have $${currentUser.character.cashOnHand.toLocaleString()}`
+                  `Insufficient cash - need ${BotBranding.formatCurrency(totalCost)}, have ${BotBranding.formatCurrency(currentUser.character.cashOnHand)}`
                 );
               }
               // Deduct from cash
@@ -281,7 +281,7 @@ export class AssetService {
             case "bank":
               if (currentUser.character.bankBalance < totalCost) {
                 throw new Error(
-                  `Insufficient bank funds - need $${totalCost.toLocaleString()}, have $${currentUser.character.bankBalance.toLocaleString()}`
+                  `Insufficient bank funds - need ${BotBranding.formatCurrency(totalCost)}, have ${BotBranding.formatCurrency(currentUser.character.bankBalance)}`
                 );
               }
               // Deduct from bank
@@ -301,10 +301,10 @@ export class AssetService {
 
               if (cashAmount > currentUser.character.cashOnHand) {
                 throw new Error(
-                  `Insufficient funds - need $${totalCost.toLocaleString()}, have $${(
+                  `Insufficient funds - need ${BotBranding.formatCurrency(totalCost)}, have ${BotBranding.formatCurrency(
                     currentUser.character.cashOnHand +
                     currentUser.character.bankBalance
-                  ).toLocaleString()}`
+                  )}`
                 );
               }
 
@@ -892,7 +892,7 @@ export class AssetService {
         if (balance.cashOnHand < cost) {
           return {
             success: false,
-            message: `Insufficient cash - need $${cost.toLocaleString()}, have $${balance.cashOnHand.toLocaleString()}`,
+            message: `Insufficient cash - need ${BotBranding.formatCurrency(cost)}, have ${BotBranding.formatCurrency(balance.cashOnHand)}`,
             error: "Insufficient cash",
           };
         }
@@ -900,7 +900,7 @@ export class AssetService {
         if (balance.bankBalance < cost) {
           return {
             success: false,
-            message: `Insufficient bank funds - need $${cost.toLocaleString()}, have $${balance.bankBalance.toLocaleString()}`,
+            message: `Insufficient bank funds - need ${BotBranding.formatCurrency(cost)}, have ${BotBranding.formatCurrency(balance.bankBalance)}`,
             error: "Insufficient bank funds",
           };
         }
@@ -910,7 +910,7 @@ export class AssetService {
         if (totalAvailable < cost) {
           return {
             success: false,
-            message: `Insufficient funds - need $${cost.toLocaleString()}, have $${totalAvailable.toLocaleString()} (cash + bank)`,
+            message: `Insufficient funds - need ${BotBranding.formatCurrency(cost)}, have ${BotBranding.formatCurrency(totalAvailable)} (cash + bank)`,
             error: "Insufficient funds",
           };
         }

--- a/src/services/CasinoService.ts
+++ b/src/services/CasinoService.ts
@@ -79,7 +79,7 @@ export class CasinoService {
           result: this.createEmptySlotResult(betAmount),
           transaction: {
             success: false,
-            message: `Bet must be between $${casinoConfig.slots.minBet.toLocaleString()} and $${casinoConfig.slots.maxBet.toLocaleString()}`,
+            message: `Bet must be between ${BotBranding.formatCurrency(casinoConfig.slots.minBet)} and ${BotBranding.formatCurrency(casinoConfig.slots.maxBet)}`,
             error: "Invalid bet amount",
           },
         };
@@ -106,7 +106,7 @@ export class CasinoService {
           result: this.createEmptySlotResult(betAmount),
           transaction: {
             success: false,
-            message: `Insufficient ${paymentMethod} funds. You need $${betAmount.toLocaleString()} but only have $${availableFunds.toLocaleString()}`,
+            message: `Insufficient ${paymentMethod} funds. You need ${BotBranding.formatCurrency(betAmount)} but only have ${BotBranding.formatCurrency(availableFunds)}`,
             error: "Insufficient funds",
           },
         };
@@ -136,7 +136,7 @@ export class CasinoService {
         transactionResult = {
           success: depositResult.success,
           message: depositResult.success
-            ? `🎉 You won $${payout.toLocaleString()}! (Profit: $${profit.toLocaleString()})`
+            ? `🎉 You won ${BotBranding.formatCurrency(payout)}! (Profit: ${BotBranding.formatCurrency(profit)})`
             : `Error processing winnings: ${depositResult.error}`,
           newBalance: depositResult.success
             ? {
@@ -157,7 +157,7 @@ export class CasinoService {
         transactionResult = {
           success: deductResult.success,
           message: deductResult.success
-            ? `💸 You lost $${betAmount.toLocaleString()}. Better luck next time!`
+            ? `💸 You lost ${BotBranding.formatCurrency(betAmount)}. Better luck next time!`
             : `Error processing bet: ${deductResult.error}`,
           newBalance: deductResult.success
             ? {
@@ -214,7 +214,7 @@ export class CasinoService {
           result: this.createEmptyRouletteResult(betType, betNumber, betAmount),
           transaction: {
             success: false,
-            message: `Bet must be between $${casinoConfig.roulette.minBet.toLocaleString()} and $${casinoConfig.roulette.maxBet.toLocaleString()}`,
+            message: `Bet must be between ${BotBranding.formatCurrency(casinoConfig.roulette.minBet)} and ${BotBranding.formatCurrency(casinoConfig.roulette.maxBet)}`,
             error: "Invalid bet amount",
           },
         };
@@ -277,7 +277,7 @@ export class CasinoService {
           result: this.createEmptyRouletteResult(betType, betNumber, betAmount),
           transaction: {
             success: false,
-            message: `Insufficient ${paymentMethod} funds. You need $${betAmount.toLocaleString()} but only have $${availableFunds.toLocaleString()}`,
+            message: `Insufficient ${paymentMethod} funds. You need ${BotBranding.formatCurrency(betAmount)} but only have ${BotBranding.formatCurrency(availableFunds)}`,
             error: "Insufficient funds",
           },
         };
@@ -307,7 +307,7 @@ export class CasinoService {
         transactionResult = {
           success: depositResult.success,
           message: depositResult.success
-            ? `🎉 You won $${payout.toLocaleString()}! (Profit: $${profit.toLocaleString()})`
+            ? `🎉 You won ${BotBranding.formatCurrency(payout)}! (Profit: ${BotBranding.formatCurrency(profit)})`
             : `Error processing winnings: ${depositResult.error}`,
           newBalance: depositResult.success
             ? {
@@ -328,7 +328,7 @@ export class CasinoService {
         transactionResult = {
           success: deductResult.success,
           message: deductResult.success
-            ? `💸 You lost $${betAmount.toLocaleString()}. The house wins this time!`
+            ? `💸 You lost ${BotBranding.formatCurrency(betAmount)}. The house wins this time!`
             : `Error processing bet: ${deductResult.error}`,
           newBalance: deductResult.success
             ? {
@@ -404,7 +404,7 @@ export class CasinoService {
       },
       {
         name: "💰 Bet Information",
-        value: `**Bet Amount:** $${result.betAmount.toLocaleString()}\n**Result:** ${
+        value: `**Bet Amount:** ${BotBranding.formatCurrency(result.betAmount)}\n**Result:** ${
           result.isWin ? "🎉 **WIN!**" : "💸 **LOSE**"
         }`,
         inline: true,
@@ -419,7 +419,7 @@ export class CasinoService {
         name: "🏆 Winning Line",
         value: `${winningIcons}\n**Multiplier:** ${
           result.multiplier
-        }x\n**Payout:** $${result.payout.toLocaleString()}\n**Profit:** $${result.profit.toLocaleString()}`,
+        }x\n**Payout:** ${BotBranding.formatCurrency(result.payout)}\n**Profit:** ${BotBranding.formatCurrency(result.profit)}`,
         inline: true,
       });
     }
@@ -479,8 +479,8 @@ export class CasinoService {
         name: "💰 Result",
         value: `**${result.isWin ? "🎉 WIN!" : "💸 LOSE"}**\n${
           result.isWin
-            ? `Payout: $${result.payout.toLocaleString()}\nProfit: $${result.profit.toLocaleString()}`
-            : `Lost: $${result.betAmount.toLocaleString()}`
+            ? `Payout: ${BotBranding.formatCurrency(result.payout)}\nProfit: ${BotBranding.formatCurrency(result.profit)}`
+            : `Lost: ${BotBranding.formatCurrency(result.betAmount)}`
         }`,
         inline: true,
       }
@@ -514,14 +514,14 @@ export class CasinoService {
     embed.addFields(
       {
         name: "🎲 Slots",
-        value: `**Min Bet:** $${casinoConfig.slots.minBet.toLocaleString()}\n**Max Bet:** $${casinoConfig.slots.maxBet.toLocaleString()}\n**How to Play:** Three matching symbols in the middle row wins!\n**House Edge:** ${(
+        value: `**Min Bet:** ${BotBranding.formatCurrency(casinoConfig.slots.minBet)}\n**Max Bet:** ${BotBranding.formatCurrency(casinoConfig.slots.maxBet)}\n**How to Play:** Three matching symbols in the middle row wins!\n**House Edge:** ${(
           casinoConfig.slots.houseEdge * 100
         ).toFixed(1)}%\n🎰 *High win frequency with exciting jackpots!*`,
         inline: true,
       },
       {
         name: "🎡 Roulette",
-        value: `**Min Bet:** $${casinoConfig.roulette.minBet.toLocaleString()}\n**Max Bet:** $${casinoConfig.roulette.maxBet.toLocaleString()}\n**How to Play:** Bet on numbers (0, 00, 1-36), colors, or ranges\n**House Edge:** ${(
+        value: `**Min Bet:** ${BotBranding.formatCurrency(casinoConfig.roulette.minBet)}\n**Max Bet:** ${BotBranding.formatCurrency(casinoConfig.roulette.maxBet)}\n**How to Play:** Bet on numbers (0, 00, 1-36), colors, or ranges\n**House Edge:** ${(
           casinoConfig.roulette.houseEdge * 100
         ).toFixed(2)}%`,
         inline: true,
@@ -613,7 +613,7 @@ export class CasinoService {
         betDescription = betType;
     }
 
-    return `**${betDescription}**\nBet: $${betAmount.toLocaleString()}`;
+    return `**${betDescription}**\nBet: ${BotBranding.formatCurrency(betAmount)}`;
   }
 
   /**
@@ -698,7 +698,7 @@ export class CasinoService {
 
       return {
         success: true,
-        message: `Deducted $${amount.toLocaleString()} from ${paymentMethod}`,
+        message: `Deducted ${BotBranding.formatCurrency(amount)} from ${paymentMethod}`,
         newBalance: {
           cashOnHand: newCashOnHand,
           bankBalance: newBankBalance,

--- a/src/utils/LevelGateValidator.ts
+++ b/src/utils/LevelGateValidator.ts
@@ -5,6 +5,7 @@
  * that match their current level and progression.
  */
 
+import { BotBranding } from "../config/bot";
 import { LevelCalculator } from "../config/economy";
 import type { GameItem } from "../data/items";
 import type { CrimeData } from "../data/crimes";
@@ -153,10 +154,10 @@ export class LevelGateValidator {
     // Check money requirement
     const moneyReq = asset.requirements?.money;
     if (moneyReq) {
-      requirements.push(`Money: $${moneyReq.toLocaleString()}`);
+      requirements.push(`Money: ${BotBranding.formatCurrency(moneyReq)}`);
       const playerMoney = player.money || 0;
       if (playerMoney < moneyReq) {
-        missingRequirements.push(`Money: $${moneyReq.toLocaleString()} (current: $${playerMoney.toLocaleString()})`);
+        missingRequirements.push(`Money: ${BotBranding.formatCurrency(moneyReq)} (current: ${BotBranding.formatCurrency(playerMoney)})`);
         isUnlocked = false;
       }
     }

--- a/src/utils/ResponseUtil.ts
+++ b/src/utils/ResponseUtil.ts
@@ -211,7 +211,7 @@ export class ResponseUtil {
       .addFields(
         {
           name: "💰 Money",
-          value: `$${character.money.toLocaleString()}`,
+          value: `${BotBranding.formatCurrency(character.money)}`,
           inline: true,
         },
         {


### PR DESCRIPTION
- Replace manual $${amount.toLocaleString()} with BotBranding.formatCurrency()
- Update CasinoService.ts: all bet amounts, payouts, and balance displays
- Update AssetService.ts: purchase costs, insufficient funds messages
- Update LevelGateValidator.ts: money requirement formatting
- Update ResponseUtil.ts: profile money display
- Update crypto.ts: fiat currency amounts only (preserve crypto formatting)
- Update assetValidation.ts: asset price displays
- Make insufficient funds casino messages private/ephemeral
- Ensure consistent currency symbol and formatting across all modules

This centralizes currency formatting and allows easy customization via environment variables (BOT_CURRENCY_SYMBOL, BOT_CURRENCY_NAME).