### PR TITLE
fix: correct import paths in deployment scripts

### DIFF
--- a/scripts/commands/forceRegisterCommands.ts
+++ b/scripts/commands/forceRegisterCommands.ts
@@ -7,7 +7,7 @@
 
 import { REST, Routes } from "discord.js";
 import dotenv from "dotenv";
-import CommandManager from "../src/utils/CommandManager";
+import CommandManager from "../../src/utils/CommandManager";
 
 dotenv.config();
 

--- a/scripts/commands/registerDevCommands.ts
+++ b/scripts/commands/registerDevCommands.ts
@@ -7,7 +7,7 @@
 
 import { REST, Routes } from "discord.js";
 import dotenv from "dotenv";
-import CommandManager from "../src/utils/CommandManager";
+import CommandManager from "../../src/utils/CommandManager";
 
 dotenv.config();
 

--- a/scripts/database/seed.ts
+++ b/scripts/database/seed.ts
@@ -6,8 +6,8 @@
  */
 
 import { PrismaClient } from "@prisma/client";
-import { GameSeeder } from "../src/utils/GameSeeder";
-import { logger } from "../src/utils/ResponseUtil";
+import { GameSeeder } from "../../src/utils/GameSeeder";
+import { logger } from "../../src/utils/ResponseUtil";
 
 const prisma = new PrismaClient();
 

--- a/scripts/database/setupSQLite.ts
+++ b/scripts/database/setupSQLite.ts
@@ -6,8 +6,8 @@
  */
 
 import { PrismaClient } from "@prisma/client";
-import { logger } from "../src/utils/ResponseUtil";
-import { initializeGameData } from "../src/utils/GameSeeder";
+import { logger } from "../../src/utils/ResponseUtil";
+import { initializeGameData } from "../../src/utils/GameSeeder";
 import fs from "fs";
 import path from "path";
 


### PR DESCRIPTION
- Fix relative import paths in scripts/ directory from ../src/ to ../../src/
- Update forceRegisterCommands.ts: CommandManager import path
- Update registerDevCommands.ts: CommandManager import path
- Update seed.ts: GameSeeder and ResponseUtil import paths
- Update setupSQLite.ts: ResponseUtil and GameSeeder import paths

Resolves TypeScript compilation errors during deployment that were preventing seeding and command registration from working properly.