### PR TITLE
feat: make casino last10 command results visible to all users

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -136,8 +136,12 @@ class MafiaWarBot {
         // Casino gambling results should be public, so defer without ephemeral flag
         if (interaction.commandName === "casino") {
           const subcommand = interaction.options.getSubcommand();
-          if (subcommand === "slots" || subcommand === "roulette") {
-            await interaction.deferReply(); // Public reply for gambling results
+          if (
+            subcommand === "slots" ||
+            subcommand === "roulette" ||
+            subcommand === "last10"
+          ) {
+            await interaction.deferReply(); // Public reply for gambling results and audit
           } else {
             await interaction.deferReply({ flags: 64 }); // Ephemeral for info/errors
           }


### PR DESCRIPTION
- Modified bot.ts to include 'last10' subcommand in public reply logic
- Roulette audit results (/casino last10) are now visible to all channel members
- Improves transparency by allowing all users to see recent roulette outcomes
- Previously was ephemeral (private), now public for audit purposes